### PR TITLE
don't download directly into the bin directory

### DIFF
--- a/bindownloader.go
+++ b/bindownloader.go
@@ -1,11 +1,10 @@
 package bindownloader
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -21,11 +20,12 @@ func LoadConfig(config io.Reader) (Config, error) {
 
 //LoadConfigFile returns a Config from the path to a config file
 func LoadConfigFile(configFile string) (Config, error) {
-	configBytes, err := ioutil.ReadFile(configFile) //nolint:gosec
+	configReader, err := os.Open(configFile) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read config file: %s", configFile)
 	}
-	return LoadConfig(bytes.NewReader(configBytes))
+	defer logCloseErr(configReader)
+	return LoadConfig(configReader)
 }
 
 // Config map binary names to Config

--- a/cmd/bindownloader/main.go
+++ b/cmd/bindownloader/main.go
@@ -51,7 +51,10 @@ arch: %s
 		os.Exit(1)
 	}
 
-	err = downloader.Install(binDir, cli.Force)
+	err = downloader.Install(bindownloader.InstallOpts{
+		TargetDir: binDir,
+		Force:     cli.Force,
+	})
 
 	kctx.FatalIfErrorf(err)
 }

--- a/downloader.go
+++ b/downloader.go
@@ -110,9 +110,18 @@ got: %s`, targetFile, d.Checksum, result)
 	return nil
 }
 
+//InstallOpts options for Install
+type InstallOpts struct {
+	// TargetDir is the directory where the executable should end up
+	TargetDir string
+	// Force - whether to force the install even if it already exists
+	Force bool
+}
+
 //Install downloads and installs a bin
-func (d *Downloader) Install(targetDir string, force bool) error {
-	if fileExists(d.binPath(targetDir)) && !force {
+func (d *Downloader) Install(opts InstallOpts) error {
+	targetDir := opts.TargetDir
+	if fileExists(d.binPath(targetDir)) && !opts.Force {
 		return nil
 	}
 	err := d.download(targetDir)

--- a/downloader.go
+++ b/downloader.go
@@ -65,14 +65,28 @@ func (d *Downloader) link(targetDir, extractDir string) error {
 	if d.LinkSource == "" {
 		return nil
 	}
+	var err error
 	if fileExists(d.binPath(targetDir)) {
-		err := rm(d.binPath(targetDir))
+		err = rm(d.binPath(targetDir))
 		if err != nil {
 			return err
 		}
 	}
-	src := filepath.Join(extractDir, filepath.FromSlash(d.LinkSource))
-	return os.Symlink(src, d.binPath(targetDir))
+	extractDir, err = filepath.Abs(extractDir)
+	if err != nil {
+		return err
+	}
+	target := d.binPath(targetDir)
+	targetDir, err = filepath.Abs(filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+
+	dst, err := filepath.Rel(targetDir, filepath.Join(extractDir, filepath.FromSlash(d.LinkSource)))
+	if err != nil {
+		return err
+	}
+	return os.Symlink(dst, d.binPath(targetDir))
 }
 
 func (d *Downloader) extract(downloadDir, extractDir string) error {

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -1,6 +1,7 @@
 package bindownloader
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -118,7 +119,7 @@ func TestDownloader_Install(t *testing.T) {
 		d := &Downloader{
 			URL:        ts.URL + "/foo/foo.tar.gz?foo=bar",
 			Checksum:   "f7fa712caea646575c920af17de3462fe9d08d7fe062b9a17010117d5fa4ed88",
-			BinName:    "foo.txt",
+			BinName:    "foo",
 			LinkSource: "bin/foo.txt",
 			Arch:       "amd64",
 			OS:         "darwin",
@@ -128,5 +129,9 @@ func TestDownloader_Install(t *testing.T) {
 			Force:     true,
 		})
 		assert.NoError(t, err)
+		linksTo, err := os.Readlink(filepath.Join(dir, "foo"))
+		assert.NoError(t, err)
+		absLinkTo := filepath.Join(dir, linksTo)
+		assert.True(t, fileExists(absLinkTo))
 	})
 }

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -92,20 +92,41 @@ func Test_downloader_validateChecksum(t *testing.T) {
 }
 
 func TestDownloader_Install(t *testing.T) {
-	dir, teardown := tmpDir(t)
-	defer teardown()
-	ts := serveFile(fooPath, "/foo/foo.tar.gz", "")
-	d := &Downloader{
-		URL:      ts.URL + "/foo/foo.tar.gz",
-		Checksum: "f7fa712caea646575c920af17de3462fe9d08d7fe062b9a17010117d5fa4ed88",
-		BinName:  "foo.txt",
-		MoveFrom: "bin/foo.txt",
-		Arch:     "amd64",
-		OS:       "darwin",
-	}
-	err := d.Install(InstallOpts{
-		TargetDir: dir,
-		Force:     true,
+	t.Run("move", func(t *testing.T) {
+		dir, teardown := tmpDir(t)
+		defer teardown()
+		ts := serveFile(fooPath, "/foo/foo.tar.gz", "foo=bar")
+		d := &Downloader{
+			URL:      ts.URL + "/foo/foo.tar.gz?foo=bar",
+			Checksum: "f7fa712caea646575c920af17de3462fe9d08d7fe062b9a17010117d5fa4ed88",
+			BinName:  "foo.txt",
+			MoveFrom: "bin/foo.txt",
+			Arch:     "amd64",
+			OS:       "darwin",
+		}
+		err := d.Install(InstallOpts{
+			TargetDir: dir,
+			Force:     true,
+		})
+		assert.NoError(t, err)
 	})
-	assert.NoError(t, err)
+
+	t.Run("link", func(t *testing.T) {
+		dir, teardown := tmpDir(t)
+		defer teardown()
+		ts := serveFile(fooPath, "/foo/foo.tar.gz", "foo=bar")
+		d := &Downloader{
+			URL:        ts.URL + "/foo/foo.tar.gz?foo=bar",
+			Checksum:   "f7fa712caea646575c920af17de3462fe9d08d7fe062b9a17010117d5fa4ed88",
+			BinName:    "foo.txt",
+			LinkSource: "bin/foo.txt",
+			Arch:       "amd64",
+			OS:         "darwin",
+		}
+		err := d.Install(InstallOpts{
+			TargetDir: dir,
+			Force:     true,
+		})
+		assert.NoError(t, err)
+	})
 }

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -103,6 +103,9 @@ func TestDownloader_Install(t *testing.T) {
 		Arch:     "amd64",
 		OS:       "darwin",
 	}
-	err := d.Install(dir, true)
+	err := d.Install(InstallOpts{
+		TargetDir: dir,
+		Force:     true,
+	})
 	assert.NoError(t, err)
 }

--- a/util.go
+++ b/util.go
@@ -1,6 +1,8 @@
 package bindownloader
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log"
@@ -15,12 +17,64 @@ func logCloseErr(closer io.Closer) {
 	}
 }
 
+// fileChecksum returns the hex checksum of a file
+func fileChecksum(filename string) (string, error) {
+	file, err := os.Open(filename) //nolint:gosec
+	if err != nil {
+		return "", err
+	}
+	defer logCloseErr(file)
+	hash := sha256.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+//fileExistsWithChecksum returns true if the file both exists and has a matching checksum
+func fileExistsWithChecksum(filename, checksum string) (bool, error) {
+	if !fileExists(filename) {
+		return false, nil
+	}
+	got, err := fileChecksum(filename)
+	if err != nil {
+		return false, err
+	}
+	return checksum == got, nil
+}
+
 //fileExists asserts that a file exists
 func fileExists(path string) bool {
 	if _, err := os.Stat(filepath.FromSlash(path)); !os.IsNotExist(err) {
 		return true
 	}
 	return false
+}
+
+func copyFile(src, dst string) error {
+	srcStat, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !srcStat.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file")
+	}
+
+	rdr, err := os.Open(src) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer logCloseErr(rdr)
+
+	writer, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcStat.Mode())
+	if err != nil {
+		return err
+	}
+	defer logCloseErr(writer)
+
+	_, err = io.Copy(writer, rdr)
+	return err
 }
 
 func rm(path string) error {


### PR DESCRIPTION
Instead of downloading and extracting files in the bin directory, this creates a subdirectory under bin named `.bindownloader` and creates separate directories for each download and extraction under there.